### PR TITLE
FIX: Address formatting

### DIFF
--- a/lib/nuca_backend/hotspots/hotspot.ex
+++ b/lib/nuca_backend/hotspots/hotspot.ex
@@ -43,7 +43,7 @@ defmodule NucaBackend.Hotspots.Hotspot do
       :total_unsterilized_cats,
       :volunteer_id
     ])
-    |> validate_required([:latitude, :longitude, :address])
+    |> validate_required([:latitude, :longitude])
     |> validate_inclusion(:status, ["ToDo", "InProgress", "Done"])
   end
 end


### PR DESCRIPTION
Frontend: When the user selects a location without a e.g postal code or street number, the address should be displayed as expected, without any "null" values.

Backend: the hotspot entity has a non-null constraint on the address field, which was removed due to the issue mentioned above. If any of the address elements are missing and there is an attempt to insert a row with an incomplete address in the hotspots table, a changeset error is raised.