### PR TITLE
FIX: Cat card volunteer name update operation

### DIFF
--- a/lib/nuca_backend_web/controllers/cat_controller.ex
+++ b/lib/nuca_backend_web/controllers/cat_controller.ex
@@ -51,7 +51,6 @@ defmodule NucaBackendWeb.CatController do
           formatter: fn entry -> %{"url" => entry} end
         )
       )
-
     cat = Cats.get_cat!(params["id"])
 
     with {:ok, %Cat{} = cat} <- Cats.update_cat(cat, params) do


### PR DESCRIPTION
## Changes

Before including these changes, updates for the name of a volunteer associated with an unsterilized cat card are not displayed immediately. Unfortunately, attempting to use Repo.preload to fix this does not work as expected. The update has to be forced by inserting the new volunteer values into the returned entity.

Check out the nuca-mobile PR to see the demo clips.