### PR TITLE
FIX: Guard the Repo.get(...) statement against a possible null volunteer ID

### DIFF
--- a/lib/nuca_backend/hotspots/hotspots.ex
+++ b/lib/nuca_backend/hotspots/hotspots.ex
@@ -35,7 +35,7 @@ defmodule NucaBackend.Hotspots do
     |> Hotspot.changeset(attrs)
     |> Repo.update()
     |> OK.flat_map(fn h ->
-      new_volunteer = Repo.get!(User, h.volunteer_id)
+      new_volunteer = if h.volunteer_id != nil, do: Repo.get!(User, h.volunteer_id), else: nil
       {:ok, Map.put(h, :volunteer, new_volunteer)}
     end)
   end


### PR DESCRIPTION
When the hotspot didn't have an associated volunteer, the Repo.get(...) failed, obviously due to the null volunteer ID.